### PR TITLE
GnuPG: fix binaries for MacOS

### DIFF
--- a/.github/workflows/gnupg_openssl.yml
+++ b/.github/workflows/gnupg_openssl.yml
@@ -89,11 +89,11 @@ jobs:
       - run: |
           brew install gawk perl
           git clone https://github.com/spack/spack.git
-          
+
           # Disables internationalization to avoid linking to
           # libintl on MacOS, since that will make the binary
           # non portable
-          git apply gnupg_openssl/gnupg_no_nls.patch
+          cd spack && git apply ../gnupg_openssl/gnupg_no_nls.patch && cd ..
           
           . spack/share/spack/setup-env.sh
           spack external find --not-buildable gawk perl

--- a/.github/workflows/gnupg_openssl.yml
+++ b/.github/workflows/gnupg_openssl.yml
@@ -89,6 +89,12 @@ jobs:
       - run: |
           brew install gawk perl
           git clone https://github.com/spack/spack.git
+          
+          # Disables internationalization to avoid linking to
+          # libintl on MacOS, since that will make the binary
+          # non portable
+          git apply gnupg_openssl/gnupg_no_nls.patch
+          
           . spack/share/spack/setup-env.sh
           spack external find --not-buildable gawk perl
           spack config add "config:install_tree:padded_length:128"

--- a/.github/workflows/gnupg_openssl.yml
+++ b/.github/workflows/gnupg_openssl.yml
@@ -87,10 +87,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: |
-          brew install gawk perl
+          # brew install gawk perl
           git clone https://github.com/spack/spack.git
           . spack/share/spack/setup-env.sh
-          spack external find --not-buildable gawk perl
+          # spack external find --not-buildable gawk perl
           spack config add "config:install_tree:padded_length:128"
           mkdir -p binary-mirror
           spack install gnupg cflags="-mmacosx-version-min=10.13" target=x86_64

--- a/.github/workflows/gnupg_openssl.yml
+++ b/.github/workflows/gnupg_openssl.yml
@@ -87,10 +87,10 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: |
-          # brew install gawk perl
+          brew install gawk perl
           git clone https://github.com/spack/spack.git
           . spack/share/spack/setup-env.sh
-          # spack external find --not-buildable gawk perl
+          spack external find --not-buildable gawk perl
           spack config add "config:install_tree:padded_length:128"
           mkdir -p binary-mirror
           spack install gnupg cflags="-mmacosx-version-min=10.13" target=x86_64

--- a/gnupg_openssl/gnupg_json.py
+++ b/gnupg_openssl/gnupg_json.py
@@ -23,7 +23,7 @@ SPEC_INFO = {
         'spec': 'gnupg@2.3: %gcc platform=linux target=aarch64',
     },
     ('centos7', 'ppc64le'): {
-        'spec': 'gnupg@2.3: gcc platform=linux target=ppc64le',
+        'spec': 'gnupg@2.3: %gcc platform=linux target=ppc64le',
     },
     ('catalina', 'x86_64'): {
         'spec': 'gnupg@2.3: %apple-clang platform=darwin target=x86_64',        

--- a/gnupg_openssl/gnupg_no_nls.patch
+++ b/gnupg_openssl/gnupg_no_nls.patch
@@ -1,0 +1,12 @@
+diff --git a/var/spack/repos/builtin/packages/gnupg/package.py b/var/spack/repos/builtin/packages/gnupg/package.py
+index 2a602d8eff..2321b9aeda 100644
+--- a/var/spack/repos/builtin/packages/gnupg/package.py
++++ b/var/spack/repos/builtin/packages/gnupg/package.py
+@@ -56,6 +56,7 @@ def configure_args(self):
+             '--disable-gnutls',
+             '--disable-ldap',
+             '--disable-regex',
++            '--disable-nls',
+             '--with-pinentry-pgm='        + self.spec['pinentry'].command.path,
+             '--with-libgpg-error-prefix=' + self.spec['libgpg-error'].prefix,
+             '--with-libgcrypt-prefix='    + self.spec['libgcrypt'].prefix,

--- a/gnupg_openssl/gnupg_no_nls.patch
+++ b/gnupg_openssl/gnupg_no_nls.patch
@@ -6,7 +6,7 @@ index 2a602d8eff..2321b9aeda 100644
              '--disable-gnutls',
              '--disable-ldap',
              '--disable-regex',
-+            '--disable-nls',
++            '--disable-nls', '--without-libintl-prefix,
              '--with-pinentry-pgm='        + self.spec['pinentry'].command.path,
              '--with-libgpg-error-prefix=' + self.spec['libgpg-error'].prefix,
              '--with-libgcrypt-prefix='    + self.spec['libgcrypt'].prefix,

--- a/gnupg_openssl/gnupg_no_nls.patch
+++ b/gnupg_openssl/gnupg_no_nls.patch
@@ -6,7 +6,7 @@ index 2a602d8eff..2321b9aeda 100644
              '--disable-gnutls',
              '--disable-ldap',
              '--disable-regex',
-+            '--disable-nls', '--without-libintl-prefix,
++            '--disable-nls', '--without-libintl-prefix',
              '--with-pinentry-pgm='        + self.spec['pinentry'].command.path,
              '--with-libgpg-error-prefix=' + self.spec['libgpg-error'].prefix,
              '--with-libgcrypt-prefix='    + self.spec['libgcrypt'].prefix,

--- a/gnupg_openssl/gnupg_no_nls.patch
+++ b/gnupg_openssl/gnupg_no_nls.patch
@@ -12,14 +12,15 @@ index 2a602d8eff..a420ccb5b7 100644
              '--with-libgpg-error-prefix=' + self.spec['libgpg-error'].prefix,
              '--with-libgcrypt-prefix='    + self.spec['libgcrypt'].prefix,
 diff --git a/var/spack/repos/builtin/packages/libgpg-error/package.py b/var/spack/repos/builtin/packages/libgpg-error/package.py
-index 2083e2e61e..65288b447f 100644
+index 2083e2e61e..0de1a018f0 100644
 --- a/var/spack/repos/builtin/packages/libgpg-error/package.py
 +++ b/var/spack/repos/builtin/packages/libgpg-error/package.py
-@@ -31,5 +31,6 @@ def configure_args(self):
+@@ -31,5 +31,7 @@ def configure_args(self):
          return [
              '--enable-static',
              '--enable-shared',
 -            '--enable-tests' if self.run_tests else '--disable-tests'
 +            '--enable-tests' if self.run_tests else '--disable-tests',
-+            '--without-libintl-prefix'
++            '--without-libintl-prefix',
++            '--disable-nls'
          ]

--- a/gnupg_openssl/gnupg_no_nls.patch
+++ b/gnupg_openssl/gnupg_no_nls.patch
@@ -1,12 +1,25 @@
 diff --git a/var/spack/repos/builtin/packages/gnupg/package.py b/var/spack/repos/builtin/packages/gnupg/package.py
-index 2a602d8eff..2321b9aeda 100644
+index 2a602d8eff..a420ccb5b7 100644
 --- a/var/spack/repos/builtin/packages/gnupg/package.py
 +++ b/var/spack/repos/builtin/packages/gnupg/package.py
-@@ -56,6 +56,7 @@ def configure_args(self):
+@@ -56,6 +56,8 @@ def configure_args(self):
              '--disable-gnutls',
              '--disable-ldap',
              '--disable-regex',
-+            '--disable-nls', '--without-libintl-prefix',
++            '--disable-nls',
++            '--without-libintl-prefix',
              '--with-pinentry-pgm='        + self.spec['pinentry'].command.path,
              '--with-libgpg-error-prefix=' + self.spec['libgpg-error'].prefix,
              '--with-libgcrypt-prefix='    + self.spec['libgcrypt'].prefix,
+diff --git a/var/spack/repos/builtin/packages/libgpg-error/package.py b/var/spack/repos/builtin/packages/libgpg-error/package.py
+index 2083e2e61e..65288b447f 100644
+--- a/var/spack/repos/builtin/packages/libgpg-error/package.py
++++ b/var/spack/repos/builtin/packages/libgpg-error/package.py
+@@ -31,5 +31,6 @@ def configure_args(self):
+         return [
+             '--enable-static',
+             '--enable-shared',
+-            '--enable-tests' if self.run_tests else '--disable-tests'
++            '--enable-tests' if self.run_tests else '--disable-tests',
++            '--without-libintl-prefix'
+         ]


### PR DESCRIPTION
Binaries produced during CI have a spurious:
```
Load command 13
          cmd LC_LOAD_DYLIB
      cmdsize 72
         name /usr/local/opt/gettext/lib/libintl.8.dylib (offset 24)
   time stamp 2 Thu Jan  1 01:00:02 1970
      current version 11.0.0
compatibility version 11.0.0
```
which makes them unusable on other platforms.